### PR TITLE
Add sample React + Supabase scripts

### DIFF
--- a/scripts/react-supabase/README.md
+++ b/scripts/react-supabase/README.md
@@ -1,0 +1,47 @@
+# React + Supabase Scripts
+
+This directory contains example React components and setup for integrating the
+Java ADK development server with a web application backed by Supabase.
+
+The scripts are intended as a starting point and can be copied into your own
+project. They assume the ADK development server is running and exposes the
+following endpoints:
+
+- `GET /agents` — returns `{ agents: string[] }` with the names of compiled agents.
+- `POST /run_sse` — run an agent via server‑sent events (not used directly here).
+- `WS /run_live` — WebSocket endpoint for interactive agent sessions.
+
+Supabase is used for storing uploaded agent source files in a bucket called
+`agent-source`.
+
+## Files
+
+- `package.json` — dependencies and dev scripts using Vite.
+- `vite.config.ts` — Vite configuration with the React plugin.
+- `src/supabaseClient.ts` — initializes the Supabase client using environment variables `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+- `src/components/AgentUploader.tsx` — upload agent source files to Supabase storage.
+- `src/components/AgentList.tsx` — fetch and display available agents from the backend.
+- `src/components/AgentChat.tsx` — connect to the WebSocket endpoint and chat with an agent.
+- `src/App.tsx` — simple application wiring the components together.
+- `src/main.tsx` — React entry point.
+
+## Usage
+
+1. Populate a `.env` file with your Supabase credentials:
+
+   ```bash
+   VITE_SUPABASE_URL=https://your-project.supabase.co
+   VITE_SUPABASE_ANON_KEY=public-anon-key
+   ```
+
+2. Install dependencies and start the dev server:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+3. Open `http://localhost:3000` to upload agent code and interact with the ADK server.
+
+These scripts are intentionally lightweight and omit styling and error handling
+for brevity.

--- a/scripts/react-supabase/package.json
+++ b/scripts/react-supabase/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "adk-web-scripts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.24.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^5.0.0"
+  }
+}

--- a/scripts/react-supabase/src/App.tsx
+++ b/scripts/react-supabase/src/App.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AgentUploader from './components/AgentUploader';
+import AgentList from './components/AgentList';
+import AgentChat from './components/AgentChat';
+
+export default function App() {
+  const [selectedAgent, setSelectedAgent] = React.useState<string | null>(null);
+  const [sessionId, setSessionId] = React.useState<string>('');
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>ADK Web Scripts</h1>
+      <AgentUploader />
+      <hr />
+      <AgentList onSelect={setSelectedAgent} />
+      {selectedAgent && (
+        <div>
+          <h2>Chat with {selectedAgent}</h2>
+          <input
+            type="text"
+            placeholder="session id"
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+          />
+          <AgentChat agentName={selectedAgent} sessionId={sessionId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/scripts/react-supabase/src/components/AgentChat.tsx
+++ b/scripts/react-supabase/src/components/AgentChat.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface Props {
+  agentName: string;
+  sessionId: string;
+}
+
+interface Message {
+  role: 'user' | 'agent';
+  text: string;
+}
+
+export default function AgentChat({ agentName, sessionId }: Props) {
+  const [messages, setMessages] = React.useState<Message[]>([]);
+  const [input, setInput] = React.useState('');
+  const [ws, setWs] = React.useState<WebSocket | null>(null);
+
+  React.useEffect(() => {
+    if (!agentName || !sessionId) return;
+    const socket = new WebSocket(
+      `/run_live?app_name=${encodeURIComponent(agentName)}&session_id=${sessionId}`
+    );
+    socket.onmessage = (ev) => {
+      const evt = JSON.parse(ev.data);
+      if (evt.type === 'AGENT_MESSAGE') {
+        setMessages((m) => [...m, { role: 'agent', text: evt.message.content.parts[0].text }]);
+      }
+    };
+    setWs(socket);
+    return () => socket.close();
+  }, [agentName, sessionId]);
+
+  const send = () => {
+    if (!ws) return;
+    ws.send(JSON.stringify({ content: { parts: [{ text: input }] } }));
+    setMessages((m) => [...m, { role: 'user', text: input }]);
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div style={{ border: '1px solid #ccc', padding: '0.5rem', height: '200px', overflow: 'auto' }}>
+        {messages.map((m, idx) => (
+          <div key={idx}><b>{m.role}:</b> {m.text}</div>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && send()}
+      />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+}

--- a/scripts/react-supabase/src/components/AgentList.tsx
+++ b/scripts/react-supabase/src/components/AgentList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface Props {
+  onSelect: (name: string) => void;
+}
+
+export default function AgentList({ onSelect }: Props) {
+  const [agents, setAgents] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    fetch('/agents')
+      .then((res) => res.json())
+      .then((data) => setAgents(data.agents ?? []))
+      .catch(() => setAgents([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Available Agents</h2>
+      <ul>
+        {agents.map((name) => (
+          <li key={name}>
+            <button onClick={() => onSelect(name)}>{name}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/scripts/react-supabase/src/components/AgentUploader.tsx
+++ b/scripts/react-supabase/src/components/AgentUploader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function AgentUploader() {
+  const [file, setFile] = React.useState<File | null>(null);
+  const [status, setStatus] = React.useState<string>('');
+
+  const upload = async () => {
+    if (!file) return;
+    setStatus('Uploading...');
+    const { data, error } = await supabase.storage
+      .from('agent-source')
+      .upload(file.name, file, { upsert: true });
+    if (error) {
+      setStatus(`Upload failed: ${error.message}`);
+    } else {
+      setStatus(`Uploaded ${data.path}`);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Upload Agent</h2>
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+      <button onClick={upload} disabled={!file}>Upload</button>
+      <div>{status}</div>
+    </div>
+  );
+}

--- a/scripts/react-supabase/src/main.tsx
+++ b/scripts/react-supabase/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/scripts/react-supabase/src/supabaseClient.ts
+++ b/scripts/react-supabase/src/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/scripts/react-supabase/tsconfig.json
+++ b/scripts/react-supabase/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/scripts/react-supabase/vite.config.ts
+++ b/scripts/react-supabase/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add `scripts/react-supabase` folder with a lightweight React setup
- implement components for uploading agent files, listing agents, and chatting via WebSocket
- document usage in `README.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686cd22b08c4832083f153b1b234bf8f